### PR TITLE
Simplify test condition

### DIFF
--- a/tradeasystems_connector/broker/email_connector.py
+++ b/tradeasystems_connector/broker/email_connector.py
@@ -89,7 +89,7 @@ class EmailConnector(BrokerConnector):
             msg['Subject'] = subject
             body = body
             msg.attach(MIMEText(body, 'plain'))
-            if html is not None and isinstance(html, str):
+            if isinstance(html, str):
                 msg.attach(MIMEText(html, 'html'))
 
             # %% Atachemnt


### PR DESCRIPTION
```
>>> isinstance(None, str)
False
```

So the first part of the condition is not needed.